### PR TITLE
Dev catching dynamodb errors bugfix

### DIFF
--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -118,18 +118,22 @@ module.exports = function(connect){
                 }
 			}
 		}, function(err, result){
-			try {
-				if (!result.Item) return fn(null, null);
-				else if (result.Item.expires && now >= result.Item.expires) {
-					fn(null, null);
-				} else {
-					var sess = result.Item.sess.S.toString();
-					sess = JSON.parse(sess);
-					fn(null, sess);
-				}
-			} catch (err) {
-				fn(err);
-			}
+            if (err) {
+                fn(err);
+            } else {
+                try {
+                    if (!result.Item) return fn(null, null);
+                    else if (result.Item.expires && now >= result.Item.expires) {
+                        fn(null, null);
+                    } else {
+                        var sess = result.Item.sess.S.toString();
+                        sess = JSON.parse(sess);
+                        fn(null, sess);
+                    }
+                } catch (err) {
+                    fn(err);
+                }
+            }
 		}.bind(this));
 	};
 


### PR DESCRIPTION
Hi,

I experienced troubles when using connect-dynamodb module for sessions handling when get method is invoked on table which have exceeded provisioned throughput.

I noticed that you use try/catch block for catching any kind of errors, but catch block will only catch exceptions, not all kind of errors.

You can notice that you try to read Item property of result object which is in some circumstances null value. So, "cannot read property Item of null" error occurred which returns error code 500: internal server error.

I added code that will first check is error variable set. If it is then pass it to the callback function fn. If err variable is not set then do try/catch block.

Please review this code and merge it on the master branch ASAP because we have this module in production.

Also it will be very good to check other similar "might be problems".

Best regards
