### PR TITLE
Enable the option of DynamoDB Local

### DIFF
--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -50,7 +50,14 @@ module.exports = function (connect) {
 	        this.AWSRegion = options.AWSRegion || 'us-east-1';
 	        AWS.config.update({region: this.AWSRegion});
 	    }
+        if (AWS.config.region == 'dynamodb-local') {
+            AWS.config.sslEnabled = false;
+            var ep = new AWS.Endpoint('http://localhost:8000');
+            this.client = new AWS.DynamoDB({endpoint: ep});
+            this.client.endpoint.hostname == 'http://localhost:8000';
+        } else {
             this.client = new AWS.DynamoDB();
+        }
         }
 
         this.table = options.table || 'sessions';


### PR DESCRIPTION
If a developer specifies 'dynamodb-local' as the region in their config, use the DynamoDBLocal tool instead of the actual live service. The DynamoDBLocal tool runs, by default, at localhost:8000. This enables offline development.

http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html
