### PR TITLE
Add ability to provide a JSON object to configure AWS, specify custom hashKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ connect-dynamodb is a DynamoDB session store backed by the [aws-sdk](https://git
     - `AWSConfigPath` Path to JSON document containing your [AWS credentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Credentials_from_Disk) (defaults to loading credentials from [environment variables](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Credentials_from_Environment_Variables)) and any additional [AWS configuration](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html) options
     - `AWSConfigJSON` JSON object containing your [AWS configuration](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html) options
   - `AWSRegion` Optional AWS region (defaults to 'us-east-1', ignored if using `AWSConfigPath` or `AWSConfigJSON`)
-  - `table` Optional DynamoDB server session table name (defaults to "sessions", currently the hash key has to be `id` - see [issue #14](https://github.com/ca98am79/connect-dynamodb/issues/14))
+  - `table` Optional DynamoDB server session table name (defaults to "sessions")
+  - `hashKey` Optional hash key (defaults to "id")
   - `prefix` Optional key prefix (defaults to "sess")
   - `reapInterval` Optional - how often expired sessions should be cleaned up (defaults to 600000)
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ connect-dynamodb is a DynamoDB session store backed by the [aws-sdk](https://git
 	  $ npm install connect-dynamodb
 
 ## Options
-  
-  - `client` An existing AWS DynamoDB object you normally get from `new AWS.DynamoDB()`
-  - `AWSConfigPath` Optional path to JSON document containing your [AWS credentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Credentials_from_Disk) (defaults to loading credentials from [environment variables](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Credentials_from_Environment_Variables))
-  - `AWSRegion` Optional AWS region (defaults to 'us-east-1')
+
+  - One of the following:
+    - `client` An existing AWS DynamoDB object you normally get from `new AWS.DynamoDB()`
+    - `AWSConfigPath` Path to JSON document containing your [AWS credentials](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Credentials_from_Disk) (defaults to loading credentials from [environment variables](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Credentials_from_Environment_Variables)) and any additional [AWS configuration](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html) options
+    - `AWSConfigJSON` JSON object containing your [AWS configuration](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html) options
+  - `AWSRegion` Optional AWS region (defaults to 'us-east-1', ignored if using `AWSConfigPath` or `AWSConfigJSON`)
   - `table` Optional DynamoDB server session table name (defaults to "sessions", currently the hash key has to be `id` - see [issue #14](https://github.com/ca98am79/connect-dynamodb/issues/14))
   - `prefix` Optional key prefix (defaults to "sess")
   - `reapInterval` Optional - how often expired sessions should be cleaned up (defaults to 600000)
@@ -24,15 +26,21 @@ connect-dynamodb is a DynamoDB session store backed by the [aws-sdk](https://git
 		// Name of the table you would like to use for sessions.
 		// Defaults to 'sessions'
 	  	table: 'myapp-sessions',
-	
+
 		// Optional path to AWS credentials (loads credentials from environment variables by default)
   	  	// AWSConfigPath: './path/to/credentials.json',
-	  
+
+		// Optional JSON object of AWS configuration options
+		    // AWSConfigJSON: {
+		    //     region: 'us-east-1',
+		    //     correctClockSkew: true
+		    // }
+
 	  	// Optional. How often expired sessions should be cleaned up.
   	  	// Defaults to 600000 (10 minutes).
   	  	reapInterval: 600000
 	};
-	
+
 	var connect = require('connect'),
 		DynamoDBStore = require('connect-dynamodb')(connect);
 	connect()
@@ -40,15 +48,15 @@ connect-dynamodb is a DynamoDB session store backed by the [aws-sdk](https://git
 		.use(connect.session({ store: new DynamoDBStore(options), secret: 'keyboard cat'}))
 
  Or with [express](http://expressjs.com/) 3.x.x
- 	
+
  	DynamoDBStore = require('connect-dynamodb')(express);
  	var app = express(
-		express.cookieParser(), 
+		express.cookieParser(),
 		express.session({ store: new DynamoDBStore(options), secret: 'keyboard cat'})
 	);
-	
+
 Or with [express](http://expressjs.com/) 4.x.x
- 	
+
  	var app = express();
  	var session = require('express-session');
  	DynamoDBStore = require('connect-dynamodb')({session: session});

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ connect-dynamodb is a DynamoDB session store backed by the [aws-sdk](https://git
   	  	// AWSConfigPath: './path/to/credentials.json',
 
 		// Optional JSON object of AWS configuration options
-		    // AWSConfigJSON: {
-		    //     region: 'us-east-1',
-		    //     correctClockSkew: true
-		    // }
+  	  	// AWSConfigJSON: {
+  	  	//     region: 'us-east-1',
+  	  	//     correctClockSkew: true
+  	  	// }
 
 	  	// Optional. How often expired sessions should be cleaned up.
   	  	// Defaults to 600000 (10 minutes).

--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -40,6 +40,7 @@ module.exports = function (connect) {
         options = options || {};
         Store.call(this, options);
         this.prefix = null == options.prefix ? 'sess:' : options.prefix;
+        this.hashKey = null == options.hashKey ? 'id' : options.hashKey;
 
         if (options.client) {
             this.client = options.client;
@@ -69,11 +70,11 @@ module.exports = function (connect) {
                 this.client.createTable({
                     TableName: this.table,
                     AttributeDefinitions: [{
-                        AttributeName: 'id',
+                        AttributeName: this.hashKey,
                         AttributeType: 'S'
                     }],
                     KeySchema: [{
-                        AttributeName: 'id',
+                        AttributeName: this.hashKey,
                         KeyType: 'HASH'
                     }],
                     ProvisionedThroughput: {

--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -44,12 +44,14 @@ module.exports = function (connect) {
         if (options.client) {
             this.client = options.client;
         } else {
-	    if (options.AWSConfigPath) {
-	        AWS.config.loadFromPath(options.AWSConfigPath);
-	    } else {
-	        this.AWSRegion = options.AWSRegion || 'us-east-1';
-	        AWS.config.update({region: this.AWSRegion});
-	    }
+      	    if (options.AWSConfigPath) {
+      	        AWS.config.loadFromPath(options.AWSConfigPath);
+            } else if (options.AWSConfigJSON) {
+                AWS.config.update(AWSConfigJSON);
+      	    } else {
+      	        this.AWSRegion = options.AWSRegion || 'us-east-1';
+      	        AWS.config.update({region: this.AWSRegion});
+      	    }
             this.client = new AWS.DynamoDB();
         }
 

--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -48,7 +48,7 @@ module.exports = function (connect) {
       	    if (options.AWSConfigPath) {
       	        AWS.config.loadFromPath(options.AWSConfigPath);
             } else if (options.AWSConfigJSON) {
-                AWS.config.update(AWSConfigJSON);
+                AWS.config.update(options.AWSConfigJSON);
       	    } else {
       	        this.AWSRegion = options.AWSRegion || 'us-east-1';
       	        AWS.config.update({region: this.AWSRegion});


### PR DESCRIPTION
This pull request is two-fold.

First, it adds the ability to provide a JSON object as `AWSConfigJSON` in lieu of providing a path of a JSON configuration file. This works well for dynamic configurations without needed to maintain multiple JSON configuration files for minor AWS configuration changes.

Second, it fixes [Issue #14](https://github.com/ca98am79/connect-dynamodb/issues/14) and allows a `hashKey` to be set. It defaults to "id".