### PR TITLE
Implemented touch and made expires TTL compatible

### DIFF
--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -106,7 +106,7 @@ module.exports = function (connect) {
     DynamoDBStore.prototype.get = function (sid, fn) {
 
         sid = this.prefix + sid;
-        var now = +new Date;
+        var now = Math.floor(Date.now() / 1000);
 
         this.client.getItem({
             TableName: this.table,
@@ -179,7 +179,7 @@ module.exports = function (connect) {
      */
 
     DynamoDBStore.prototype.reap = function (fn) {
-        var now = +new Date;
+        var now = Math.floor(Date.now() / 1000);
         var options = {
             endkey: '[' + now + ',{}]'
         };
@@ -249,7 +249,8 @@ module.exports = function (connect) {
      * @return {Integer}      The expire on timestamp.
      */
     DynamoDBStore.prototype.getExpiresValue = function (sess) {
-      return typeof sess.cookie.maxAge === 'number' ? (+new Date()) + sess.cookie.maxAge : (+new Date()) + oneDayInMilliseconds;
+      var expires = typeof sess.cookie.maxAge === 'number' ? (+new Date()) + sess.cookie.maxAge : (+new Date()) + oneDayInMilliseconds;
+      return Math.floor(expires / 1000);
     }
 
     /**

--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -148,7 +148,7 @@ module.exports = function (connect) {
 
     DynamoDBStore.prototype.set = function (sid, sess, fn) {
         sid = this.prefix + sid;
-        var expires = typeof sess.cookie.maxAge === 'number' ? (+new Date()) + sess.cookie.maxAge : (+new Date()) + oneDayInMilliseconds;
+        var expires = this.getExpiresValue(sess);
         sess = JSON.stringify(sess);
 
         var params = {
@@ -240,6 +240,43 @@ module.exports = function (connect) {
                 }
             }
         }, fn || function () {});
+    };
+
+
+    /**
+     * Calculates the expire value based on the configuration.
+     * @param  {Object} sess Session object.
+     * @return {Integer}      The expire on timestamp.
+     */
+    DynamoDBStore.prototype.getExpiresValue = function (sess) {
+      return typeof sess.cookie.maxAge === 'number' ? (+new Date()) + sess.cookie.maxAge : (+new Date()) + oneDayInMilliseconds;
+    }
+
+    /**
+     * Touches the session row to update it's expire value.
+     * @param  {String}   sid  Session id.
+     * @param  {Object}   sess Session object.
+     * @param  {Function} fn   Callback.
+     */
+    DynamoDBStore.prototype.touch  = function (sid, sess, fn) {
+      sid = this.prefix + sid;
+      var expires = this.getExpiresValue(sess);
+      var params = {
+          TableName: this.table,
+          UpdateExpression: "set expires = :e",
+          ExpressionAttributeValues:{
+              ":e": {
+                N:  JSON.stringify(expires)
+              }
+          },
+          ReturnValues:"UPDATED_NEW"
+      };
+      params.Key = {};
+      params.Key[this.hashKey] = {
+          'S': sid
+      }
+
+      this.client.updateItem(params, fn || function () {});
     };
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -84,20 +84,25 @@ describe('DynamoDBStore', function () {
                 table: 'sessions-test'
             });
 
-            maxAge = ((+new Date()) + 2000);
+            maxAge = (Math.floor((Date.now() + 2000) / 1000) );
             store.set('1234', sess, function () {});
         });
 
         it('should touch data correctly', function (done) {
+            this.timeout(4000);
             var store = new DynamoDBStore({
                 client: client,
                 table: 'sessions-test'
             });
-            store.touch('1234', sess, function (err, res) {
-                if (err) throw err;
-                res.Attributes.expires.N.should.be.above(maxAge);
-                done();
-            });
+            setTimeout(function() {
+              store.touch('1234', sess, function (err, res) {
+                  if (err) throw err;
+                  var expires = res.Attributes.expires.N;
+                  expires.should.be.above(maxAge);
+                  (expires - maxAge).should.be.above(1.5);
+                  done();
+              });
+            }, 1510);
         });
 
     });

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,37 @@ describe('DynamoDBStore', function () {
         });
 
     });
+    describe('Touching', function () {
+        var sess = {
+            cookie: {
+                maxAge: 2000
+            },
+            name: 'tj'
+        };
+        var maxAge = null;
+        before(function () {
+            var store = new DynamoDBStore({
+                client: client,
+                table: 'sessions-test'
+            });
+
+            maxAge = ((+new Date()) + 2000);
+            store.set('1234', sess, function () {});
+        });
+
+        it('should touch data correctly', function (done) {
+            var store = new DynamoDBStore({
+                client: client,
+                table: 'sessions-test'
+            });
+            store.touch('1234', sess, function (err, res) {
+                if (err) throw err;
+                res.Attributes.expires.N.should.be.above(maxAge);
+                done();
+            });
+        });
+
+    });
     describe('Destroying', function () {
         before(function () {
             var store = new DynamoDBStore({
@@ -117,6 +148,7 @@ describe('DynamoDBStore', function () {
         });
 
         it('should reap data correctly', function (done) {
+            this.timeout(5000); // increased timeout for local dynamo
             var store = new DynamoDBStore({
                 client: client,
                 table: 'sessions-test'

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,7 @@ describe('DynamoDBStore', function () {
 
     });
     describe('Getting', function () {
-        before(function () {
+        before(function (done) {
             var store = new DynamoDBStore({
                 client: client,
                 table: 'sessions-test'
@@ -50,7 +50,7 @@ describe('DynamoDBStore', function () {
                     maxAge: 2000
                 },
                 name: 'tj'
-            }, function () {});
+            }, done);
         });
 
         it('should get data correctly', function (done) {
@@ -78,14 +78,14 @@ describe('DynamoDBStore', function () {
             name: 'tj'
         };
         var maxAge = null;
-        before(function () {
+        before(function (done) {
             var store = new DynamoDBStore({
                 client: client,
                 table: 'sessions-test'
             });
 
             maxAge = (Math.floor((Date.now() + 2000) / 1000) );
-            store.set('1234', sess, function () {});
+            store.set('1234', sess, done);
         });
 
         it('should touch data correctly', function (done) {
@@ -99,7 +99,7 @@ describe('DynamoDBStore', function () {
                   if (err) throw err;
                   var expires = res.Attributes.expires.N;
                   expires.should.be.above(maxAge);
-                  (expires - maxAge).should.be.above(1.5);
+                  (expires - maxAge).should.be.aboveOrEqual(1);
                   done();
               });
             }, 1510);
@@ -107,7 +107,7 @@ describe('DynamoDBStore', function () {
 
     });
     describe('Destroying', function () {
-        before(function () {
+        before(function (done) {
             var store = new DynamoDBStore({
                 client: client,
                 table: 'sessions-test'
@@ -117,7 +117,7 @@ describe('DynamoDBStore', function () {
                     maxAge: 2000
                 },
                 name: 'tj'
-            }, function () {});
+            }, done);
         });
 
         it('should destroy data correctly', function (done) {


### PR DESCRIPTION
Implemented touch as requested on #23 and changed the expires field to work on seconds units instead of millis to address #39. This way to use TTL we just need to enable it on the table and select the 'expires' field.