### PR TITLE
Make possible to use   npm install --no-optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test": "mocha"
   },
   "dependencies": {
-    "aws-sdk": "*",
     "connect": "*"
   },
   "devDependencies": {
@@ -19,7 +18,9 @@
   "engines": {
     "node": "*"
   },
-  "optionalDependencies": {},
+  "optionalDependencies": {
+    "aws-sdk": "*",
+  },
   "homepage": "https://github.com/ca98am79/connect-dynamodb",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Make no change to  
    npm install
but now we can do 
   npm install --no-optional

wich reduce the size of the connect-dynamodb from 30+Mo  to a few Ko

Why: 
You may wich to send this package in AWS Lambda without AWS-SDK as recommended by AWS