### PR TITLE
Use the hashKey provided in config

### DIFF
--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -108,15 +108,16 @@ module.exports = function (connect) {
         sid = this.prefix + sid;
         var now = Math.floor(Date.now() / 1000);
 
-        this.client.getItem({
+        var params = {
             TableName: this.table,
-            Key: {
-                id: {
-                    'S': sid
-                }
-            },
+            Key: {},
             ConsistentRead: true
-        }, function (err, result) {
+        };
+        params.Key[this.hashKey] = {
+            'S': sid
+        };
+
+        this.client.getItem(params, function (err, result) {
 
             if (err) {
                 fn(err);
@@ -154,9 +155,6 @@ module.exports = function (connect) {
         var params = {
             TableName: this.table,
             Item: {
-                id: {
-                    'S': sid
-                },
                 expires: {
                     'N': JSON.stringify(expires)
                 },
@@ -168,6 +166,10 @@ module.exports = function (connect) {
                 }
             }
         };
+        params.Item[this.hashKey] = {
+          'S': sid
+        };
+
         this.client.putItem(params, fn);
     };
 
@@ -193,7 +195,7 @@ module.exports = function (connect) {
                     "ComparisonOperator": "LT"
                 }
             },
-            AttributesToGet: ["id"]
+            AttributesToGet: [this.hashKey]
         };
         this.client.scan(params, function onScan(err, data) {
             if (err) return fn && fn(err);
@@ -210,7 +212,7 @@ module.exports = function (connect) {
 
         function destroyDataAt(index) {
             if (data.Count > 0 && index < data.Count) {
-                var sid = data.Items[index].id.S;
+                var sid = data.Items[index][this.hashKey].S;
                 sid = sid.substring(self.prefix.length, sid.length);
                 self.destroy(sid, function () {
                     destroyDataAt(index + 1);
@@ -232,14 +234,14 @@ module.exports = function (connect) {
 
     DynamoDBStore.prototype.destroy = function (sid, fn) {
         sid = this.prefix + sid;
-        this.client.deleteItem({
+        var params = {
             TableName: this.table,
-            Key: {
-                id: {
-                    'S': sid
-                }
-            }
-        }, fn || function () {});
+            Key: {}
+        };
+        params.Key[this.hashKey] = {
+            'S': sid
+        };
+        this.client.deleteItem(params, fn || function () {});
     };
 
 
@@ -264,6 +266,7 @@ module.exports = function (connect) {
       var expires = this.getExpiresValue(sess);
       var params = {
           TableName: this.table,
+          Key: {},
           UpdateExpression: "set expires = :e",
           ExpressionAttributeValues:{
               ":e": {
@@ -272,7 +275,6 @@ module.exports = function (connect) {
           },
           ReturnValues:"UPDATED_NEW"
       };
-      params.Key = {};
       params.Key[this.hashKey] = {
           'S': sid
       }


### PR DESCRIPTION
Earlier versions of this library would perform some actions using the
provided hashKey and others using the default `id`.

This commit makes the behaviour more consistent, and will always use the
provided hashKey (while still defaulting to `id` of course!).

Any issues let me know, but I haven't changed much and have tried to follow the style guidelines you've used.

This PR should resolve https://github.com/ca98am79/connect-dynamodb/issues/35