### PR TITLE
Support passing express-session directly as a param in init

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ With [express 4](http://expressjs.com/)
     var DynamoDBStore = require('connect-dynamodb')({session: session});
     app.use(session({store: new DynamoDBStore(options), secret: 'keyboard cat'}));
 
+OR 
+
+    var app = express();
+    var session = require('express-session');
+    var DynamoDBStore = require('connect-dynamodb')(session);
+    app.use(session({store: new DynamoDBStore(options), secret: 'keyboard cat'}));
+
 ## Testing
 
 If you want to run the tests locally and have the AWS environment variables setup you can run the command:

--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -27,7 +27,7 @@ module.exports = function (connect) {
      * Connect's Store.
      */
 
-    var Store = connect.session.Store;
+    var Store = connect.Store || connect.session.Store;
 
     /**
      * Initialize DynamoDBStore with the given `options`.

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,20 @@ if (process.env.AWS_CONFIG_JSON) {
     client = new AWS.DynamoDB(config);
 }
 
+describe('ConnectDynamoDB', function () {
+    describe('Constructor', function () {
+        it('should take session as argument', function () {
+            const dynamoDbStore = require(__dirname + '/../lib/connect-dynamodb.js')(session);
+            dynamoDbStore.should.be.an.instanceOf(Function);
+        });
+
+        it('should take session as one of the options', function () {
+            const dynamoDbStore = require(__dirname + '/../lib/connect-dynamodb.js')({session: session});
+            dynamoDbStore.should.be.an.instanceOf(Function);
+        });
+    })
+})
+
 describe('DynamoDBStore', function () {
     describe('Instantiation', function () {
         it('should be able to be created', function () {


### PR DESCRIPTION
Addresses issue: https://github.com/ca98am79/connect-dynamodb/issues/54
