### PR TITLE
Fix #44 - don't crash on invalid session data stored in DDB

### DIFF
--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -123,7 +123,7 @@ module.exports = function (connect) {
                 fn(err);
             } else {
                 try {
-                    if (!result.Item) return fn(null, null);
+                    if (!(result.Item && result.Item.sess && result.Item.sess.S)) return fn(null, null);
                     else if (result.Item.expires && now >= result.Item.expires) {
                         fn(null, null);
                     } else {
@@ -211,8 +211,8 @@ module.exports = function (connect) {
         var self = this;
 
         function destroyDataAt(index) {
-            if (data.Count > 0 && index < data.Count) {
-                var sid = data.Items[index][this.hashKey].S;
+            if (data.Count > 0 && index < data.Count && data.Items && data.Items[index] && data.Items[index][self.hashKey]) {
+                var sid = data.Items[index][self.hashKey].S;
                 sid = sid.substring(self.prefix.length, sid.length);
                 self.destroy(sid, function () {
                     destroyDataAt(index + 1);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Mike Carson <ca98am79@gmail.com> (http://ca98am79.com)",
   "main": "./index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "debugtest": "mocha --inspect-brk"
   },
   "dependencies": {
     "connect": "*"
@@ -13,6 +14,7 @@
   "devDependencies": {
     "express-session": "*",
     "mocha": "*",
+    "sinon": "*",
     "should": "*"
   },
   "engines": {


### PR DESCRIPTION
There seem to be cases where a session would be stored without the actual payload:

{"expires":{"N":"1503608283"},"id":{"S":"sess:awkd99aLsGDn3Kmrv7JFSaMzPTL3rzfH"}}

`store.get()` would throw an error, as it doesn't test the existence of a `sess` element. Change the code to test its existence before reading it. Return as if the session had expired in case of non-existence.

Fix another crasher where `destroyDataAt()` would try to access `this.hashKey` after a context switch. Use `self.hashKey` instead.