### PR TITLE
Update Readme to add describe table permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ _(Replace __\<AWS ACCOUNT ID\>__, __\<TABLE NAME\>__ and __\<SOURCE IP AND BITMA
             "Effect": "Allow",
             "Action": [
                 "dynamodb:CreateTable",
+                "dynamodb:DescribeTable",
                 "dynamodb:PutItem",
                 "dynamodb:DeleteItem",
                 "dynamodb:GetItem",


### PR DESCRIPTION
This library calls describeTable which the docs do not include as a required permission. If not present the library will attempt to create the table and will then throw 
 ResourceInUseException because the table exists