### PR TITLE
fix: comparing apples to apples on expire session

### DIFF
--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -123,7 +123,7 @@ module.exports = function (connect) {
             } else {
                 try {
                     if (!(result.Item && result.Item.sess && result.Item.sess.S)) return fn(null, null);
-                    else if (result.Item.expires && now >= result.Item.expires) {
+                    else if (result.Item.expires && now >= +result.Item.expires.N) {
                         fn(null, null);
                     } else if (!result.Item.sess) {
                         // Session isn't on the item for some reason. This seems to happen when


### PR DESCRIPTION
result.Item.expires returns an { N: '666' } object and not a number, this was preventing the session from being expired past its expiration date on the datastore.