### PR TITLE
Add skipThrowMissingSpecialKeys option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Rational defaults are set but can be overridden in the options object. Credentia
                 name: 'userId', // The session key
                 type: 'S' // The DyanamoDB attribute type
             }
-        ]
+        ],
+        // Optional skip throw missing special keys in session, if set true
+        skipThrowMissingSpecialKeys: true,
     };
 
 With [connect](https://github.com/senchalabs/connect)

--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -43,6 +43,7 @@ module.exports = function (connect) {
         this.readCapacityUnits = null == options.readCapacityUnits ? 5 : parseInt(options.readCapacityUnits, 10);
         this.writeCapacityUnits = null == options.writeCapacityUnits ? 5 : parseInt(options.writeCapacityUnits, 10);
         this.specialKeys = null == options.specialKeys ? [] : options.specialKeys;
+        this.skipThrowMissingSpecialKeys = null == options.skipThrowMissingSpecialKeys? false : !!options.specialKeys;
 
         if (options.client) {
             this.client = options.client;
@@ -184,7 +185,7 @@ module.exports = function (connect) {
             }
         });
 
-        if (missingKeys.length > 0) {
+        if (!this.skipThrowMissingSpecialKeys && missingKeys.length > 0) {
             throw Error('Session missing special keys' + JSON.stringify(missingKeys));
         }
 


### PR DESCRIPTION
Add option to prevent missing special keys exception.
My specific use case is that special keys can be updated after inserted at first.