### PR TITLE
Fix Bug Where Cookie's maxAge is Incorrectly Applied as Divided by 1000 to expires

### DIFF
--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -18,9 +18,9 @@ const {
 } = require("@aws-sdk/client-dynamodb");
 
 /**
- * One day in milliseconds.
+ * One day in seconds.
  */
-const oneDayInMilliseconds = 86400000;
+const oneDayInSeconds = 86400;
 
 /**
  * Return the `DynamoDBStore` extending `connect`'s session Store.
@@ -339,11 +339,12 @@ module.exports = function (connect) {
    * @return {Integer}      The expire on timestamp.
    */
   DynamoDBStore.prototype.getExpiresValue = function (sess) {
+    const now = Math.floor(Date.now() / 1000);
     const expires =
       typeof sess.cookie.maxAge === "number"
-        ? +new Date() + sess.cookie.maxAge
-        : +new Date() + oneDayInMilliseconds;
-    return Math.floor(expires / 1000);
+        ? now + sess.cookie.maxAge
+        : now + oneDayInSeconds;
+    return expires;
   };
 
   /**


### PR DESCRIPTION
The maxAge of the cookie is treated as milliseconds even though it is set to seconds.
This can be resolved by obtaining the current time in seconds and then treating it as such.