### PR TITLE
Remove problematic export module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,10 +6,6 @@ import {
   ScalarAttributeType,
 } from "@aws-sdk/client-dynamodb";
 
-declare module "connect-dynamodb" {
-  export = ConnectDynamoDB;
-}
-
 declare function ConnectDynamoDB<Session extends Record<string, unknown>>(
   connect: typeof session
 ): DynamoDBStore<Session>;


### PR DESCRIPTION
Removing `declare module "connect-dynamodb"` fixes the typescript  compilation


```
$ node -v
v18.16.0
```

```
$ tsc -v
Version 5.0.4
```


```
$ tsc  --project tsconfig-build.json
node_modules/connect-dynamodb/index.d.ts:10:3 - error TS2666: Exports and export assignments are not permitted in module augmentations.

10   export = ConnectDynamoDB;
     ~~~~~~


Found 1 error in node_modules/connect-dynamodb/index.d.ts:10
```