### PR TITLE
Fix expiry based on TTL; fix error handling of `dynamodb:DescribeTable`

### DIFF
--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -93,10 +93,14 @@ module.exports = function (connect) {
       .then(() => {
         this.initialized = true;
       })
-      .catch(() => {
-        return this.createSessionsTable().then(() => {
-          this.initialized = true;
-        });
+      .catch((err) => {
+        if (err.name == 'ResourceNotFoundException') {
+          return this.createSessionsTable().then(() => {
+            this.initialized = true;
+          });
+        } else {
+          throw err;
+        }
       });
   };
 
@@ -342,7 +346,7 @@ module.exports = function (connect) {
     const now = Math.floor(Date.now() / 1000);
     const expires =
       typeof sess.cookie.maxAge === "number"
-        ? now + sess.cookie.maxAge
+        ? now + (sess.cookie.maxAge / 1000)
         : now + oneDayInSeconds;
     return expires;
   };


### PR DESCRIPTION
Addresses this issue:
https://github.com/ca98am79/connect-dynamodb/issues/86

Also changes error handling for `DescribeTable` to assume the table does not exist only if the error is `ResourceNotFoundException`