### PR TITLE
feat: add initialized option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,11 @@ declare namespace ConnectDynamoDB {
      * Upgrade to DynamoDB's TimeToLive configuration.
      */
     reapInterval?: number;
+    /**
+     * Disable initialization.
+     * Useful if the table already exists or if you want to skip existence checks in a serverless environment such as AWS Lambda.
+     */
+    initialized?: boolean;
   }
 
   interface DynamoDBStoreOptionsSpecialKey {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -33,6 +33,7 @@ const options: DynamoDBStoreOptions = {
   writeCapacityUnits: 25,
   specialKeys: specialKeysOptions,
   skipThrowMissingSpecialKeys: true,
+  initialized: true,
 };
 
 expectType<express.RequestHandler>(

--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -45,7 +45,7 @@ module.exports = function (connect) {
   function DynamoDBStore(options) {
     options = options || {};
     Store.call(this, options);
-    this.initialized = false;
+    this.initialized = options.initialized || false;
     this.prefix = null == options.prefix ? "sess:" : options.prefix;
     this.hashKey = null == options.hashKey ? "id" : options.hashKey;
     this.readCapacityUnits =

--- a/test/test.js
+++ b/test/test.js
@@ -148,6 +148,28 @@ describe("DynamoDBStore", () => {
         await client.send(new DeleteTableCommand({ TableName: tableName }));
       });
     });
+
+    describe("skip initializing", () => {
+      const tableName = "sessions-test-" + Math.random().toString();
+      const store = new DynamoDBStore({
+        client,
+        table: tableName,
+        initialized: true,
+      });
+      const describeSessionsTableSpy = sinon.spy(
+        store,
+        "describeSessionsTable"
+      );
+      const createSessionsTableSpy = sinon.spy(store, "createSessionsTable");
+
+      it("Should skip table existence checks and creation", async () => {
+        describeSessionsTableSpy.notCalled.should.equal(true);
+        createSessionsTableSpy.notCalled.should.equal(true);
+        await store.initialize();
+        describeSessionsTableSpy.notCalled.should.equal(true);
+        createSessionsTableSpy.notCalled.should.equal(true);
+      });
+    });
   });
 
   describe("Setting", () => {


### PR DESCRIPTION
This ought to fix https://github.com/ca98am79/connect-dynamodb/issues/67.

In an environment like AWS Lambda, `DescribeTableCommand` is executed each time because it is instantiated each time.
This proposal would allow us to skip the `DescribeTableCommand` execution.

Since there seemed to be no CI, I am attaching the test results in a local environment.
![image](https://github.com/9b3kuq5phwuk4txw/connect-dynamodb/assets/85531675/0a7affd0-dcac-401c-85e6-7a55a1cdf133)
![image](https://github.com/9b3kuq5phwuk4txw/connect-dynamodb/assets/85531675/2ded358e-9f18-4116-8c0a-4adcac628953)