### PR TITLE
fix: NUMBER_VALUE cannot be converted to String on specialKeys

### DIFF
--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -228,7 +228,7 @@ module.exports = function (connect) {
       this.specialKeys.forEach((key) => {
         if (typeof sess[key.name] !== "undefined") {
           const item = {};
-          item[key.type] = sess[key.name];
+          item[key.type] = key.type === 'N' ? JSON.stringify(sess[key.name]) : sess[key.name];
           params.Item[key.name] = item;
         } else {
           missingKeys.push(key.name);

--- a/test/test.js
+++ b/test/test.js
@@ -193,6 +193,44 @@ describe("DynamoDBStore", () => {
         );
       });
     });
+
+    it("should store data correctly with specialKeys option", async () => {
+      const store = new DynamoDBStore({
+        client: client,
+        table: tableName,
+        specialKeys: [
+          { name: 'number_field', type: 'N' }
+        ]
+      });
+      const randomNum = Math.floor(Math.random() * 1000) + 1;
+
+      await new Promise((resolve, reject) => {
+        store.set(
+          sessionId,
+          {
+            cookie: {
+              maxAge: 2000,
+            },
+            number_field: randomNum,
+          },
+          (err) => {
+            if (err) return reject(err);
+            resolve();
+          }
+        );
+      });
+
+      return new Promise((resolve, reject) => {
+        store.get(sessionId, function (err, res) {
+          if (err) return reject(err);
+
+          res.cookie.should.eql({ maxAge: 2000 });
+          res.number_field.should.eql(randomNum);
+
+          resolve();
+        });
+      });
+    });
   });
 
   describe("Getting", () => {


### PR DESCRIPTION
This ought to fix https://github.com/ca98am79/connect-dynamodb/issues/99.

The following is a description of a number that should be a string.
https://docs.aws.amazon.com/ja_jp/amazondynamodb/latest/APIReference/API_AttributeValue.html

![image](https://github.com/user-attachments/assets/623a1b0f-3b39-4100-b7d3-14485d61cf85)
