### PR TITLE
feat: Add `expiresIn` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ unless the `client` options is provided to override them.
   ☣️ Legacy reap behaviors use DynamoDB [`scan`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-dynamodb/classes/scancommand.html)
   functionality that can incur significant costs. Should instead enable [DynamoDB TTL](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html)
   and select the `expires` field. TODO should we just remove it since we're already making a breaking change?
-- `expiresIn` Optional set the number of seconds for DynamoDB TTL. Defaults to the cookie's maxAge.
+- `expiresIn` Optional set the number of seconds for DynamoDB TTL. Defaults to the cookie's maxAge. Must be a positive integer.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ unless the `client` options is provided to override them.
   ☣️ Legacy reap behaviors use DynamoDB [`scan`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-dynamodb/classes/scancommand.html)
   functionality that can incur significant costs. Should instead enable [DynamoDB TTL](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html)
   and select the `expires` field. TODO should we just remove it since we're already making a breaking change?
+- `expiresIn` Optional set the number of seconds for DynamoDB TTL. Defaults to the cookie's maxAge.
 
 ## Usage
 
@@ -42,6 +43,8 @@ var options = {
   ],
   // Optional skip throw missing special keys in session, if set true
   skipThrowMissingSpecialKeys: true,
+  // Optional set the number of seconds for DynamoDB TTL
+  expiresIn: 3600,
 };
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,13 @@ declare namespace ConnectDynamoDB {
      * Useful if the table already exists or if you want to skip existence checks in a serverless environment such as AWS Lambda.
      */
     initialized?: boolean;
+    /**
+     * Set the number of seconds added to the item expiry time.
+     *
+     * Setting this to 0 will use the `maxAge` value from the session cookie.
+     * @default 0
+     */
+    expiresIn?: number;
   }
 
   interface DynamoDBStoreOptionsSpecialKey {

--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -68,6 +68,7 @@ module.exports = function (connect) {
     if (this.reapInterval > 0) {
       this._reap = setInterval(this.reap.bind(this), this.reapInterval);
     }
+    this.expiresIn = null == options.expiresIn ? 0 : options.expiresIn
   }
 
   /*
@@ -344,11 +345,17 @@ module.exports = function (connect) {
    */
   DynamoDBStore.prototype.getExpiresValue = function (sess) {
     const now = Math.floor(Date.now() / 1000);
-    const expires =
+
+    if (this.expiresIn != 0) {
+      return now + this.expiresIn;
+    }
+    else {
+      const expires =
       typeof sess.cookie.maxAge === "number"
         ? now + (sess.cookie.maxAge / 1000)
         : now + oneDayInSeconds;
     return expires;
+    }
   };
 
   /**

--- a/lib/connect-dynamodb.js
+++ b/lib/connect-dynamodb.js
@@ -68,7 +68,20 @@ module.exports = function (connect) {
     if (this.reapInterval > 0) {
       this._reap = setInterval(this.reap.bind(this), this.reapInterval);
     }
-    this.expiresIn = null == options.expiresIn ? 0 : options.expiresIn
+    if (options.expiresIn) {
+      if (!Number.isInteger(options.expiresIn)) {
+        console.warn("`expiresIn` must be an integer. Reverting to default behaviour");
+        this.expiresIn = 0;
+      }
+      else if (options.expiresIn < 0) {
+        console.warn("Negative `expiresIn` values are not supported. Reverting to default behaviour");
+        this.expiresIn = 0;
+      } else {
+        this.expiresIn = options.expiresIn;
+      }
+    } else {
+      this.expiresIn = 0;
+    }
   }
 
   /*

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ const {
   DynamoDBClient,
   CreateTableCommand,
   DeleteTableCommand,
+  GetItemCommand,
   ScalarAttributeType,
 } = require("@aws-sdk/client-dynamodb");
 const ConnectDynamoDB = require(__dirname + "/../lib/connect-dynamodb.js");
@@ -230,6 +231,40 @@ describe("DynamoDBStore", () => {
           resolve();
         });
       });
+    });
+
+    it("should set correct expiry when expiresIn option is set", async () => {
+      const storeWithExpiry = new DynamoDBStore({
+        client: client,
+        table: tableName,
+        expiresIn: 1000
+      });
+      const beforeTime = Math.floor(Date.now() / 1000);
+      
+      await new Promise((resolve, reject) => {
+        storeWithExpiry.set(
+          sessionId,
+          {
+            cookie: { maxAge: 2000 },
+            name: "test"
+          },
+          (err) => {
+            if (err) return reject(err);
+            resolve();
+          }
+        );
+      });
+
+      const result = await client.send(
+        new GetItemCommand({
+          TableName: tableName,
+          Key: { id: { S: "sess:" + sessionId } }
+        })
+      );
+      
+      const expiryValue = parseInt(result.Item.expires.N);
+      const expectedExpiry = beforeTime + 1000;
+      expiryValue.should.be.approximately(expectedExpiry, 2);
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -79,8 +79,6 @@ describe("DynamoDBStore", () => {
         })
         .finally(done);
     });
-<<<<<<< Updated upstream
-=======
 
     it("should store a valid expiresIn", () => {
       const store = new DynamoDBStore({
@@ -105,7 +103,6 @@ describe("DynamoDBStore", () => {
       });
       store.expiresIn.should.equal(0);
     });
->>>>>>> Stashed changes
   });
 
   describe("Initializing", () => {

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,16 @@ describe("DynamoDBStore", () => {
   const sessionId = Math.random().toString();
 
   describe("Instantiation", () => {
+    let consoleWarnStub;
+
+    beforeEach(() => {
+      consoleWarnStub = sinon.stub(console, 'warn');
+    })
+
+    afterEach(() => {
+      consoleWarnStub.restore();
+    })
+
     it("should be able to be created", () => {
       store.should.be.an.instanceOf(DynamoDBStore);
     });
@@ -69,6 +79,33 @@ describe("DynamoDBStore", () => {
         })
         .finally(done);
     });
+<<<<<<< Updated upstream
+=======
+
+    it("should store a valid expiresIn", () => {
+      const store = new DynamoDBStore({
+        table: "sessions-test",
+        expiresIn: 3600
+      });
+      store.expiresIn.should.equal(3600);
+    });
+
+    it("should revert expiresIn to 0 when set to a non-integer", () => {
+      const store = new DynamoDBStore({
+        table: "sessions-test",
+        expiresIn: 1.5
+      });
+      store.expiresIn.should.equal(0);
+    });
+
+    it("should revert expiresIn to 0 when set to a negative integer", () => {
+      const store = new DynamoDBStore({
+        table: "sessions-test",
+        expiresIn: -10
+      });
+      store.expiresIn.should.equal(0);
+    });
+>>>>>>> Stashed changes
   });
 
   describe("Initializing", () => {
@@ -174,6 +211,16 @@ describe("DynamoDBStore", () => {
   });
 
   describe("Setting", () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers(1000000000);
+    })
+
+    afterEach(() => {
+      clock.restore();
+    })
+
     it("should store data correctly", async () => {
       return new Promise((resolve, reject) => {
         const name = Math.random().toString();
@@ -239,7 +286,6 @@ describe("DynamoDBStore", () => {
         table: tableName,
         expiresIn: 1000
       });
-      const beforeTime = Math.floor(Date.now() / 1000);
       
       await new Promise((resolve, reject) => {
         storeWithExpiry.set(
@@ -263,8 +309,7 @@ describe("DynamoDBStore", () => {
       );
       
       const expiryValue = parseInt(result.Item.expires.N);
-      const expectedExpiry = beforeTime + 1000;
-      expiryValue.should.be.approximately(expectedExpiry, 2);
+      expiryValue.should.equal(1000000 + 1000);
     });
   });
 


### PR DESCRIPTION
This allows users to override the default expiry behavior when using DynamoDB TTL to expire sessions from the table. This would be useful, for example, if they wanted to use a browser session scoped cookie as the session cookie (with no maxAge attribute) but needed a shorter TTL than the default '1 day from now'.

If this parameter is not provided then there will be no change to the current behaviour. I think that means this can be released as a minor version change.

> For full disclosure, the example I give about session cookies is exactly what I want to do.